### PR TITLE
Replace `ensure_resource` with base class and add `package_source` parameter

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,4 @@
+fixtures:
+  repositories:
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
+    systemd: 'https://github.com/camptocamp/puppet-systemd'

--- a/README.md
+++ b/README.md
@@ -8,11 +8,34 @@ Puppet module for configuring [spiped][spiped] tunnels.
 
 ## Requirements
 
-* Debian >= 8 / Ubuntu >= 15.04 / similar systems
+* Debian >= 8 / Ubuntu >= 16.04 or similar systems that provide an `spiped` package.
 * systemd as init
 
-The init requirement rules out many versions of Debian or Ubuntu. If you can't
-run systemd as init, this module is not useful to you.
+### RedHat systems
+
+This module can also work with RedHat systems, but you are responsible for providing the spiped package.
+
+Either use the `package_source` parameter, or make sure your system has a repository setup that includes
+the `spiped` package.
+
+eg.
+
+```puppet
+class { 'spiped':
+  package_source => '/path/to/spiped.rpm',
+}
+```
+
+or
+
+```puppet
+yumrepo { 'spiped':
+  baseurl => 'http://repos.example.com/spiped',
+  descr   => 'Internal spiped package repo',
+  enabled => true,
+  before  => Class['spiped'],
+}
+```
 
 ## Usage
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,23 @@
+class spiped(
+  Optional[String[1]] $package_source = undef,
+)
+{
+  if $package_source {
+    $package_provider = $facts['os']['family'] ? {
+      'RedHat' => 'rpm',
+      'Debian' => 'dpkg',
+    }
+  } else {
+    $package_provider = undef
+  }
+
+  package { 'spiped':
+    ensure   => present,
+    provider => $package_provider,
+    source   => $package_source,
+  }
+
+  file { '/etc/spiped':
+    ensure => directory,
+  }
+}

--- a/manifests/tunnel.pp
+++ b/manifests/tunnel.pp
@@ -4,8 +4,8 @@ define spiped::tunnel(
   $dest,
   $secret,
 ) {
-  ensure_resource('package', 'spiped', {'ensure' => 'present'})
-  ensure_resource('file', '/etc/spiped', {'ensure' => 'directory'})
+  assert_private()
+  include spiped
 
   $keyfile = "/etc/spiped/${title}.key"
 
@@ -31,5 +31,6 @@ define spiped::tunnel(
     ensure    => running,
     enable    => true,
     subscribe => Systemd::Unit_file["spiped-${title}.service"],
+    require   => Package['spiped'],
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,5 +10,33 @@
     "dependencies": [
         { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.3.1 < 7.0.0" },
         { "name": "camptocamp/systemd", "version_requirement": ">= 1.1.0 < 3.0.0" }
+    ],
+    "operatingsystem_support": [
+      {
+        "operatingsystem": "RedHat",
+        "operatingsystemrelease": [
+          "7"
+        ]
+      },
+      {
+        "operatingsystem": "CentOS",
+        "operatingsystemrelease": [
+          "7"
+        ]
+      },
+      {
+        "operatingsystem": "Debian",
+        "operatingsystemrelease": [
+          "8",
+          "9"
+        ]
+      },
+      {
+        "operatingsystem": "Ubuntu",
+        "operatingsystemrelease": [
+          "16.04",
+          "18.04"
+        ]
+      }
     ]
 }

--- a/spec/classes/spiped_spec.rb
+++ b/spec/classes/spiped_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'spiped' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('spiped') }
+        it { is_expected.to contain_package('spiped').only_with_ensure('present') }
+        it { is_expected.to contain_file('/etc/spiped').only_with_ensure('directory') }
+      end
+
+      context 'with package_source' do
+        case facts[:osfamily]
+        when 'Debian'
+          let(:params) { { 'package_source' => '/path/to/spiped.deb' } }
+
+          it {
+            is_expected.to contain_package('spiped').
+              with(
+                ensure: 'present',
+                provider: 'dpkg',
+                source: '/path/to/spiped.deb'
+              )
+          }
+        else
+          let(:params) { { 'package_source' => '/path/to/spiped.rpm' } }
+
+          it {
+            is_expected.to contain_package('spiped').
+              with(
+                ensure: 'present',
+                provider: 'rpm',
+                source: '/path/to/spiped.rpm'
+              )
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/spiped_tunnel_client_spec.rb
+++ b/spec/defines/spiped_tunnel_client_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'spiped::tunnel::client' do
+  let(:title) { 'redis' }
+  let(:params) do
+    {
+      source: '/var/run/redis.sock',
+      dest:   'redis-host:1234',
+      secret: 'hunter2'
+    }
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+      it {
+        is_expected.to contain_spiped__tunnel('redis').with(
+          type: 'client',
+          source: '/var/run/redis.sock',
+          dest:   'redis-host:1234',
+          secret: 'hunter2'
+        )
+      }
+      it {
+        is_expected.to contain_file('/etc/spiped/redis.key').with(
+          owner:      'root',
+          group:      'root',
+          mode:       '0600',
+          show_diff:  false,
+          content:    'hunter2'
+        )
+      }
+      it {
+        is_expected.to contain_file('/lib/systemd/system/spiped-redis.service').
+          with_ensure('absent').
+          that_comes_before('Systemd::Unit_file[spiped-redis.service]')
+      }
+
+      describe 'unit file' do
+        let(:content) { catalogue.resource('systemd::unit_file', 'spiped-redis.service').send(:parameters)[:content] }
+
+        it { is_expected.to contain_systemd__unit_file('spiped-redis.service') }
+        it 'Description' do
+          expect(content).to include('Description=spiped tunnel (redis)')
+        end
+        it 'ExecStart' do
+          expect(content).to include('ExecStart=/usr/bin/spiped -e -D -g -F -k \'/etc/spiped/redis.key\' -p /dev/null -s \'/var/run/redis.sock\' -t \'redis-host:1234\'')
+        end
+      end
+
+      it {
+        is_expected.to contain_service('spiped-redis').with(
+          ensure: 'running',
+          enable: true
+        ).that_requires('Package[spiped]').that_subscribes_to('Systemd::Unit_file[spiped-redis.service]')
+      }
+    end
+  end
+end

--- a/spec/defines/spiped_tunnel_server_spec.rb
+++ b/spec/defines/spiped_tunnel_server_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'spiped::tunnel::server' do
+  let(:title) { 'redis' }
+  let(:params) do
+    {
+      source: '0.0.0.0:1234',
+      dest:   '/var/run/redis.sock',
+      secret: 'hunter2'
+    }
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+      it {
+        is_expected.to contain_spiped__tunnel('redis').with(
+          type: 'server',
+          source: '0.0.0.0:1234',
+          dest:   '/var/run/redis.sock',
+          secret: 'hunter2'
+        )
+      }
+      it {
+        is_expected.to contain_file('/etc/spiped/redis.key').with(
+          owner:      'root',
+          group:      'root',
+          mode:       '0600',
+          show_diff:  false,
+          content:    'hunter2'
+        )
+      }
+      it {
+        is_expected.to contain_file('/lib/systemd/system/spiped-redis.service').
+          with_ensure('absent').
+          that_comes_before('Systemd::Unit_file[spiped-redis.service]')
+      }
+
+      describe 'unit file' do
+        let(:content) { catalogue.resource('systemd::unit_file', 'spiped-redis.service').send(:parameters)[:content] }
+
+        it { is_expected.to contain_systemd__unit_file('spiped-redis.service') }
+        it 'Description' do
+          expect(content).to include('Description=spiped tunnel (redis)')
+        end
+        it 'ExecStart' do
+          expect(content).to include('ExecStart=/usr/bin/spiped -d -g -F -k \'/etc/spiped/redis.key\' -p /dev/null -s \'0.0.0.0:1234\' -t \'/var/run/redis.sock\'')
+        end
+      end
+
+      it {
+        is_expected.to contain_service('spiped-redis').with(
+          ensure: 'running',
+          enable: true
+        ).that_requires('Package[spiped]').that_subscribes_to('Systemd::Unit_file[spiped-redis.service]')
+      }
+    end
+  end
+end


### PR DESCRIPTION
By having a base class that can be included by multiple instances of
`spiped::tunnel`, we can remove the use of `ensure_resource`.

This also makes it possible to provide parameters via the base class.
I've added `package_source`.  This parameter can be used on OSes that
don't ship a `spiped` package.

This commit also contains new rspec-puppet tests and a README update
explaining how to use the module on RedHat family systems.